### PR TITLE
Release 1.2.5 (125006)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,7 +18,7 @@ android {
         applicationId = "de.dertyp7214.rboardthemecreator"
         minSdk = 23
         targetSdk = 34
-        versionCode = 125005
+        versionCode = 125006
         versionName = "1.2.5"
 
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
⚠️ Warning:
• Last Android 6 and 7 update, the next version is only supported from Android 8 and above.

🔧 New dependencies changes:
• Update Activity to 1.9.0
• Update Browser to 1.8.0
• Update Commons-text to 1.12.0
• Update Core(-ktx) to 1.13.0
• Update Firebase-bom to 32.8.1
• Update Firebase-analytics(-ktx) to 21.6.2
• Update Fragment(-ktx) to 1.8.0-alpha02
• Update Kotlin to 1.9.23
• Update Webkit to 1.12.0-alpha01